### PR TITLE
fixed layout on admin-settings view for desktop version

### DIFF
--- a/resources/views/admin-settings.blade.php
+++ b/resources/views/admin-settings.blade.php
@@ -2,7 +2,9 @@
 
 @section('content')
 
-<div class="flex flex-col md:flex-row h-full min-h-screen">
+<!-- <div class="flex flex-col md:flex-row h-full min-h-screen"> -->
+<div class="flex flex-col md:flex-row h-screen">
+<!-- <div class="flex flex-col min-h-screen"> -->
         
       <!-- Sidebar -->
   <x-admin-sidebar>

--- a/resources/views/components/search-user-table.blade.php
+++ b/resources/views/components/search-user-table.blade.php
@@ -13,7 +13,8 @@
 </div>
 
 <!-- Users Table -->
-<div class="w-full bg-white rounded-lg shadow-lg overflow-hidden mb-6 overflow-x-auto">
+
+<div class="w-full max-w-4xl mx-auto bg-white rounded-lg shadow-lg overflow-hidden mb-6 overflow-x-auto">
     <table class="w-full min-w-max text-left border-collapse">
         <thead>
             <tr class="bg-gradient-to-br from-[#0b1a3a] to-[#142d5c] shadow-md rounded-lg p-5 text-white">


### PR DESCRIPTION
fixed layout on admin-settings view for desktop version. mobile version i got stuck with, the footer appear for me half way across the page and i don't understand why